### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,4 @@
 language: ruby
 rvm:
-  - 2.0
-  - 2.1
-  - 2.2
-  - jruby
-  - rbx-2
-  - jruby-head
+  - 2.2.2
   - ruby-head
-matrix:
-  allow_failures:
-  - rvm: ruby-head
-  - rvm: jruby-head

--- a/README.md
+++ b/README.md
@@ -79,13 +79,7 @@ end
 
 ## Compatibility & Versioning
 
-This project is designed to work with Ruby 2.0.0 or greater. While it may work on other version of Ruby, below are the platform and runtime versions officially supported and regularly tested against.
-
-Platform | Versions
--------- | --------
-MRI | 2.0.0, 2.1.x, 2.2.x, 2.3.x
-JRuby | 1.7.x, 9.0.0.0
-Rubinius | 2.x
+This project is designed to work with MRI Ruby 2.2.2 or greater. It may work on other versions of Ruby.
 
 All releases adhere to strict [semantic versioning](http://semver.org). For Example, major.minor.patch-pre (aka. stick.carrot.oops-peek).
 


### PR DESCRIPTION
It looks like the ActiveSupport dependency from graphql-ruby requires we have Ruby >=2.2.2. This PR removes other versions from the `.travis.yml` and `README.md`.