### PR TITLE
Relax graphql dependency

### DIFF
--- a/graphql-relay-walker.gemspec
+++ b/graphql-relay-walker.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.files       += Dir.glob("lib/**/*.rb")
   s.homepage    = "https://github.com/github/graphql-relay-walker"
 
-  s.add_dependency "graphql", "~> 0.19"
+  s.add_dependency "graphql", ">= 0.19"
 
   s.add_development_dependency "rake",           "~> 11.3"
   s.add_development_dependency "rspec",          "~> 3.5"


### PR DESCRIPTION
Version 1.2.1 of the graphql gem is now out