### PR TITLE
Fixes for GraphQL 1.0.0+

### DIFF
--- a/lib/graphql/relay/walker/query_builder.rb
+++ b/lib/graphql/relay/walker/query_builder.rb
@@ -76,7 +76,7 @@ module GraphQL::Relay::Walker
     # created AST was invalid for having no selections.
     def inline_fragment_ast(type, with_children: true)
       make(GraphQL::Language::Nodes::InlineFragment) do |if_ast|
-        if_ast.type = type.name
+        if_ast.type = make_type_name_node(type.name)
 
         if with_children
           type.all_fields.each do |field|
@@ -252,6 +252,16 @@ module GraphQL::Relay::Walker
     else
       def valid_input?(type, input)
         type.valid_input?(input)
+      end
+    end
+
+    if GraphQL::VERSION >= "1.0.0"
+      def make_type_name_node(type_name)
+        GraphQL::Language::Nodes::TypeName.new(name: type_name)
+      end
+    else
+      def make_type_name_node(type_name)
+        type_name
       end
     end
   end

--- a/lib/graphql/relay/walker/query_builder.rb
+++ b/lib/graphql/relay/walker/query_builder.rb
@@ -106,7 +106,7 @@ module GraphQL::Relay::Walker
 
       # Bail unless we have the required arguments.
       return unless field.arguments.reject do |_, arg|
-        arg.type.valid_input?(nil)
+        valid_input?(arg.type, nil)
       end.all? do |name, _|
         arguments.key?(name)
       end
@@ -242,6 +242,17 @@ module GraphQL::Relay::Walker
     # Returns a six character random String.
     def random_alias
       6.times.map { (SecureRandom.random_number(26) + 97).chr }.join
+    end
+
+    if GraphQL::VERSION >= "1.1.0"
+      def valid_input?(type, input)
+        allow_all = GraphQL::Schema::Warden.new(schema, ->(_) { false })
+        type.valid_input?(input, allow_all)
+      end
+    else
+      def valid_input?(type, input)
+        type.valid_input?(input)
+      end
     end
   end
 end


### PR DESCRIPTION
Might have jumped the gun a bit on #6 😁 

There's two fixes in this PR:

* GraphQL 1.1.0+ supports dynamic schema visibility. On 1.1.0+, `GraphQL::BaseType#valid_input?` takes a second `warden` argument that controls visibility of items in the schema. The fix here is to construct a warden that allows everything and pass it in.

* GraphQL 1.0.0+ represents the type name in a fragment condition (`... on T { }`) as a `TypeName` node rather than a raw string. Even though versions below 1.0.0 use a raw string, we can still build an AST that uses a `TypeName` here since versions below 1.0.0 still know how to print `TypeName` nodes when generating GraphQL source text from ASTs

cc @mastahyeti @github/platform-interface 