### PR TITLE
Add support for GraphQL::Wardens of version 1.4.0

### DIFF
--- a/lib/graphql/relay/walker/query_builder.rb
+++ b/lib/graphql/relay/walker/query_builder.rb
@@ -244,7 +244,12 @@ module GraphQL::Relay::Walker
       6.times.map { (SecureRandom.random_number(26) + 97).chr }.join
     end
 
-    if GraphQL::VERSION >= "1.1.0"
+    if GraphQL::VERSION >= "1.4.0"
+      def valid_input?(type, input)
+        allow_all = GraphQL::Schema::Warden.new(->(_) { false }, schema: schema, context: nil)
+        type.valid_input?(input, allow_all)
+      end
+    elsif GraphQL::VERSION >= "1.1.0"
       def valid_input?(type, input)
         allow_all = GraphQL::Schema::Warden.new(schema, ->(_) { false })
         type.valid_input?(input, allow_all)


### PR DESCRIPTION
The method fingerprint of GraphQL::Schema::Warden has changed in graphql-ruby 1.4.0. Warden's first argument is now the mask, and then two keyword arguments, schema and context as per https://git.io/vM8aG.

This commit updates that method signature in the query builder code.

---

/cc @mastahyeti & @brandonblack for review