### PR TITLE
Use valid_isolated_input? in place of valid_input?

### DIFF
--- a/lib/graphql/relay/walker/query_builder.rb
+++ b/lib/graphql/relay/walker/query_builder.rb
@@ -106,11 +106,7 @@ module GraphQL::Relay::Walker
 
       # Bail unless we have the required arguments.
       return unless field.arguments.reject do |_, arg|
-        if GraphQL::VERSION >= "1.5.6"
-          type.valid_isolated_input?(arg.type)
-        else
-          valid_input?(arg.type)
-        end
+        valid_input?(arg.type, nil)
       end.all? do |name, _|
         arguments.key?(name)
       end

--- a/lib/graphql/relay/walker/query_builder.rb
+++ b/lib/graphql/relay/walker/query_builder.rb
@@ -244,7 +244,12 @@ module GraphQL::Relay::Walker
       12.times.map { (SecureRandom.random_number(26) + 97).chr }.join
     end
 
-    if GraphQL::VERSION >= "1.4.0"
+    if GraphQL::VERSION >= "1.5.6"
+      def valid_input?(type, input)
+        allow_all = GraphQL::Schema::Warden.new(->(_) { false }, schema: schema, context: nil)
+        type.valid_isolated_input?(input, allow_all)
+      end
+    elsif GraphQL::VERSION >= "1.4.0"
       def valid_input?(type, input)
         allow_all = GraphQL::Schema::Warden.new(->(_) { false }, schema: schema, context: nil)
         type.valid_input?(input, allow_all)

--- a/lib/graphql/relay/walker/query_builder.rb
+++ b/lib/graphql/relay/walker/query_builder.rb
@@ -246,8 +246,7 @@ module GraphQL::Relay::Walker
 
     if GraphQL::VERSION >= "1.5.6"
       def valid_input?(type, input)
-        allow_all = GraphQL::Schema::Warden.new(->(_) { false }, schema: schema, context: nil)
-        type.valid_isolated_input?(input, allow_all)
+        type.valid_isolated_input?(input)
       end
     elsif GraphQL::VERSION >= "1.4.0"
       def valid_input?(type, input)

--- a/lib/graphql/relay/walker/query_builder.rb
+++ b/lib/graphql/relay/walker/query_builder.rb
@@ -106,7 +106,11 @@ module GraphQL::Relay::Walker
 
       # Bail unless we have the required arguments.
       return unless field.arguments.reject do |_, arg|
-        valid_input?(arg.type, nil)
+        if GraphQL::VERSION >= "1.5.6"
+          type.valid_isolated_input?(arg.type)
+        else
+          valid_input?(arg.type)
+        end
       end.all? do |name, _|
         arguments.key?(name)
       end


### PR DESCRIPTION
The graphql-ruby gem has been updated to [v1.5.6](https://github.com/rmosolgo/graphql-ruby/releases/tag/v1.5.6), and in it, the following [deprecation notice](https://github.com/rmosolgo/graphql-ruby/blob/d1dc92621de7a39eb987518a252aaa8ba1d8c615/CHANGELOG.md#deprecations-1) appears:

> - Calling `coerce_result`, `coerce_input`, `valid_input?` or `validate_input` without a `ctx` is deprecated. #667 Use `coerce_isolated_result` `coerce_isolated_input`, `valid_isolated_input?`, `validate_input` to explicitly bypass `ctx`.

This pull request updates a reference to `valid_input?` in the gem to use its new context-less counterpart, `valid_isolated_input?`.

---

/cc @gjtorikian, @kdaigle, @mastahyeti for review