### PR TITLE
Bump version to v0.0.8

### DIFF
--- a/graphql-relay-walker.gemspec
+++ b/graphql-relay-walker.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "graphql-relay-walker"
-  s.version     = "0.0.7"
+  s.version     = "0.0.8"
   s.licenses    = ["MIT"]
   s.summary     = "A tool for traversing your GraphQL schema to proactively detect potential data access vulnerabilities."
   s.authors     = ["Ben Toews"]


### PR DESCRIPTION
In order to cut a new release. It looks like we have branch protections in place to avoid pushing directly to `master`:

```
$ git push
Counting objects: 3, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (3/3), done.
Writing objects: 100% (3/3), 939 bytes | 0 bytes/s, done.
Total 3 (delta 2), reused 0 (delta 0)
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: error: At least one approved review is required
To https://github.com/github/graphql-relay-walker.git
 ! [remote rejected] master -> master (protected branch hook declined)
error: failed to push some refs to 'https://github.com/github/graphql-relay-walker.git'
```

---

/cc @gjtorikian & @mastahyeti as other maintainers of the gem.