### PR TITLE
Empty selection sets are no longer syntactically valid

### DIFF
--- a/lib/graphql/relay/walker/query_builder.rb
+++ b/lib/graphql/relay/walker/query_builder.rb
@@ -1,7 +1,7 @@
 module GraphQL::Relay::Walker
   class QueryBuilder
     DEFAULT_ARGUMENTS = {"first" => 5}
-    BASE_QUERY = "query($id: ID!) { node(id: $id) {} }"
+    BASE_QUERY = "query($id: ID!) { node(id: $id) { id } }"
 
     attr_reader :schema, :connection_arguments, :ast
 

--- a/spec/fixtures/swapi_query.graphql
+++ b/spec/fixtures/swapi_query.graphql
@@ -1,5 +1,6 @@
 query($id: ID!) {
   node(id: $id) {
+    id
     ... on Film {
       speciesConnection(first: 5) {
         edges {


### PR DESCRIPTION
A selection set must have fields as per the GraphQL spec.

`graphql-ruby` used to return this as a validation error, but now (https://github.com/rmosolgo/graphql-ruby/pull/1268) returns it as a parse error.

This PR adds to the base query's selection set to prevent this code from crashing.

Functionality wise, I don't think it changes anything.

cc @mastahyeti 