### PR TITLE
Drop support for GraphQL <1.5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,3 @@ rvm:
 branches:
   only:
     - master
-env:
-  - ""
-  - "GRAPHQL_19=true"

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-if ENV["GRAPHQL_19"]
-  puts "1.9-dev compatibility mode"
-  gem "graphql", github: "rmosolgo/graphql-ruby", branch: "1.9-dev"
-  gem "graphql-client", github: "github/graphql-client", branch: "support-1.9-dev"
-end

--- a/lib/graphql/relay/walker/query_builder.rb
+++ b/lib/graphql/relay/walker/query_builder.rb
@@ -267,34 +267,12 @@ module GraphQL::Relay::Walker
       12.times.map { (SecureRandom.random_number(26) + 97).chr }.join
     end
 
-    if GraphQL::VERSION >= '1.5.6'
-      def valid_input?(type, input)
-        type.valid_isolated_input?(input)
-      end
-    elsif GraphQL::VERSION >= '1.4.0'
-      def valid_input?(type, input)
-        allow_all = GraphQL::Schema::Warden.new(->(_) { false }, schema: schema, context: nil)
-        type.valid_input?(input, allow_all)
-      end
-    elsif GraphQL::VERSION >= '1.1.0'
-      def valid_input?(type, input)
-        allow_all = GraphQL::Schema::Warden.new(schema, ->(_) { false })
-        type.valid_input?(input, allow_all)
-      end
-    else
-      def valid_input?(type, input)
-        type.valid_input?(input)
-      end
+    def valid_input?(type, input)
+      type.valid_isolated_input?(input)
     end
 
-    if GraphQL::VERSION >= '1.0.0'
-      def make_type_name_node(type_name)
-        GraphQL::Language::Nodes::TypeName.new(name: type_name)
-      end
-    else
-      def make_type_name_node(type_name)
-        type_name
-      end
+    def make_type_name_node(type_name)
+      GraphQL::Language::Nodes::TypeName.new(name: type_name)
     end
   end
 end


### PR DESCRIPTION
It's been over 2 years since 1.5.6, so I think it's safe to drop it. 

Specifically, I'm testing against `1.10.0.dev` which _fails_ this test because `1.10.0.dev` is _less than_ `1.5.6`! So, the wrong branch was being activated here.

There's still a few `.respond_to?` checks for 1.9+ compatibility, though. I didn't touch those.